### PR TITLE
Change x-checker-data to stable-only

### DIFF
--- a/io.github.shiiion.primehack.yml
+++ b/io.github.shiiion.primehack.yml
@@ -37,6 +37,7 @@ modules:
         x-checker-data:
           type: anitya
           project-id: 1749
+          stable-only: true
           url-template: https://github.com/libusb/libusb/releases/download/v$version/libusb-$version.tar.bz2
 
   # needed for the emulate bluetooth adapter feature to work
@@ -62,6 +63,7 @@ modules:
         x-checker-data:
           type: anitya
           project-id: 10029
+          stable-only: true
           url-template: https://www.kernel.org/pub/linux/bluetooth/bluez-$version.tar.xz
 
   # enables motion controls on non-wii controllers (switch, ps4, etc)
@@ -78,6 +80,7 @@ modules:
         x-checker-data:
           type: anitya
           project-id: 20540
+          stable-only: true
           url-template: https://www.freedesktop.org/software/libevdev/libevdev-$version.tar.xz
 
   # needed for screensaver inhibition


### PR DESCRIPTION
With this the bot won't try to upgrade to rc versions of the libraries.
It should prevent you from getting any more garbage pull requests like https://github.com/flathub/io.github.shiiion.primehack/pull/3 

I've pushed this change to `org.DolphinEmu.dolphin-emu`, I figured you'd want it too.