### PR TITLE
Fix dolphin name collision

### DIFF
--- a/io.github.shiiion.primehack.yml
+++ b/io.github.shiiion.primehack.yml
@@ -2,10 +2,10 @@ app-id: io.github.shiiion.primehack
 runtime: org.kde.Platform
 runtime-version: 5.15-21.08
 sdk: org.kde.Sdk
-command: dolphin-emu-wrapper
-rename-desktop-file: dolphin-emu.desktop
+command: primehack-wrapper
+rename-desktop-file: primehack.desktop
 rename-icon: dolphin-emu
-rename-appdata-file: dolphin-emu.appdata.xml
+rename-appdata-file: primehack.appdata.xml
 finish-args:
   - --device=all
   # the file picker uses portals but the set
@@ -102,10 +102,12 @@ modules:
     cleanup:
       - /share/man
     post-install:
-      - install -D dolphin-emu-wrapper /app/bin/dolphin-emu-wrapper
-      - install -Dm644 appdata.xml /app/share/appdata/dolphin-emu.appdata.xml
-      - sed -i -e 's/"2048"/"512"/g' /app/share/icons/hicolor/scalable/apps/dolphin-emu.svg
-      - desktop-file-edit --set-key=Exec --set-value='dolphin-emu-wrapper' /app/share/applications/dolphin-emu.desktop
+      - install -D primehack-wrapper /app/bin/primehack-wrapper
+      - install -Dm644 appdata.xml /app/share/appdata/primehack.appdata.xml
+      - rm /app/share/icons/hicolor/scalable/apps/dolphin-emu.svg
+      - mv /app/share/applications/dolphin-emu.desktop /app/share/applications/primehack.desktop
+      - desktop-file-edit --set-key=Exec --set-value='primehack-wrapper' /app/share/applications/primehack.desktop
+      - desktop-file-edit --set-key=Name --set-value='PrimeHack' /app/share/applications/primehack.desktop
     sources:
       - type: git
         url: https://github.com/shiiion/dolphin.git
@@ -128,4 +130,4 @@ modules:
           - test -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
           - done
           - dolphin-emu "$@"
-        dest-filename: dolphin-emu-wrapper
+        dest-filename: primehack-wrapper


### PR DESCRIPTION
PrimeHack only provides a raster icon, by deleting `dolphin-emu.svg` the correct icon is displayed.
Changing the Name field in the desktop file will hopefully stop GNOME Software from listing it as "Dolphin Emulator".
The rest of the changes aren't strictly necessary.

| before (which is primehack?) | after |
| -- | -- |
| ![Screenshot from 2022-11-10 11-55-58](https://user-images.githubusercontent.com/334272/201085175-4faf1678-3d8e-420d-b0be-7f84e9d8fd92.png) | ![Screenshot from 2022-11-10 11-48-05](https://user-images.githubusercontent.com/334272/201085262-7cf200ae-dec2-44a0-87d9-bc682591e1d7.png) |


![Screenshot from 2022-11-22 19-30-31](https://user-images.githubusercontent.com/334272/203404794-9964068e-f04e-4148-a368-99bbfe8e6fe9.png)


Fixes #14 #8 #6