### PR TITLE
Update package to use 22.08 runtime

### DIFF
--- a/io.github.shiiion.primehack.yml
+++ b/io.github.shiiion.primehack.yml
@@ -1,6 +1,6 @@
 app-id: io.github.shiiion.primehack
 runtime: org.kde.Platform
-runtime-version: 5.15-21.08
+runtime-version: 5.15-22.08
 sdk: org.kde.Sdk
 command: primehack-wrapper
 rename-desktop-file: primehack.desktop


### PR DESCRIPTION
This enables building the flatpak with Mesa 22.08 which is necessary for anyone using an RDNA 3 based GPU.

Building with this change worked for me and allowed my GPU to show up in the graphics settings page. Additionally I was able to launch MP1 where before nothing would happen.