### PR TITLE
End botspam by properly upgrading from bluez 5.65

### DIFF
--- a/io.github.shiiion.primehack.yml
+++ b/io.github.shiiion.primehack.yml
@@ -54,12 +54,15 @@ modules:
       - --disable-a2dp
       - --disable-avrcp
       - --disable-network
+      - --disable-obex
+      - --disable-bap 
+      - --disable-mcp
       - --with-dbusconfdir=/app/etc
       - --with-dbussessionbusdir=/app/usr/lib/system-services
     sources:
       - type: archive
-        url: https://www.kernel.org/pub/linux/bluetooth/bluez-5.65.tar.xz
-        sha256: 2565a4d48354b576e6ad92e25b54ed66808296581c8abb80587051f9993d96d4
+        url: https://www.kernel.org/pub/linux/bluetooth/bluez-5.66.tar.xz
+        sha256: 39fea64b590c9492984a0c27a89fc203e1cdc74866086efb8f4698677ab2b574
         x-checker-data:
           type: anitya
           project-id: 10029


### PR DESCRIPTION
flathub bot is repeatedly opening merge requests trying to update bluez from 5.65, however, these keep failing.

Getting it to build properly will stop these.