### PR TITLE
Upgrade runtime to 6.5 and drop bundled bluez dependency

### DIFF
--- a/io.github.shiiion.primehack.yml
+++ b/io.github.shiiion.primehack.yml
@@ -16,8 +16,7 @@ finish-args:
   - --socket=x11
   - --share=network
   - --share=ipc
-  # along with the bluez module, required for the
-  # emulated bluetooth adapter feature to work.
+  # required for the emulated bluetooth adapter feature to work.
   - --allow=bluetooth
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
   - --talk-name=org.freedesktop.ScreenSaver
@@ -39,35 +38,6 @@ modules:
           project-id: 1749
           stable-only: true
           url-template: https://github.com/libusb/libusb/releases/download/v$version/libusb-$version.tar.bz2
-
-  # needed for the emulate bluetooth adapter feature to work
-  - name: bluez
-    config-opts:
-      - --enable-library
-      - --disable-manpages
-      - --disable-udev
-      - --disable-tools
-      - --disable-cups
-      - --disable-monitor
-      - --disable-client
-      - --disable-systemd
-      - --disable-a2dp
-      - --disable-avrcp
-      - --disable-network
-      - --disable-obex
-      - --disable-bap
-      - --disable-mcp
-      - --with-dbusconfdir=/app/etc
-      - --with-dbussessionbusdir=/app/usr/lib/system-services
-    sources:
-      - type: archive
-        url: https://www.kernel.org/pub/linux/bluetooth/bluez-5.66.tar.xz
-        sha256: 39fea64b590c9492984a0c27a89fc203e1cdc74866086efb8f4698677ab2b574
-        x-checker-data:
-          type: anitya
-          project-id: 10029
-          stable-only: true
-          url-template: https://www.kernel.org/pub/linux/bluetooth/bluez-$version.tar.xz
 
   # enables motion controls on non-wii controllers (switch, ps4, etc)
   # requires a udev rule enabling Motion Sensors access

--- a/io.github.shiiion.primehack.yml
+++ b/io.github.shiiion.primehack.yml
@@ -1,6 +1,6 @@
 app-id: io.github.shiiion.primehack
 runtime: org.kde.Platform
-runtime-version: 5.15-22.08
+runtime-version: '6.5'
 sdk: org.kde.Sdk
 command: primehack-wrapper
 rename-desktop-file: primehack.desktop


### PR DESCRIPTION
As a bonus this will put an end the current bot spam with bluez updates! 😅

- Upgrade kde runtime to `6.5`.
- Drop bluez module, it is already included in the runtime, so we no longer need to build it separately. 

Closes #10, #11, #12, #16, #17, #19, #22, #23 and #24.