### PR TITLE
Fixed erratic inputs on steam deck & updated primehack to v1.0.7a

### DIFF
--- a/Steam-Deck-Control-Fix.patch
+++ b/Steam-Deck-Control-Fix.patch
@@ -1,0 +1,37 @@
+From ed3bf410c016ac9f84e7362101f1d831f16dc430 Mon Sep 17 00:00:00 2001
+From: Vicki Pfau <vi@endrift.com>
+Date: Tue, 9 Jan 2024 20:49:38 -0800
+Subject: [PATCH] Steam Deck: Pad out feature report to 64 bytes
+
+Also update the names of the setting post-Steam Deck commits to SDL
+
+Fixes https://bugs.dolphin-emu.org/issues/13412
+---
+ .../ControllerInterface/SteamDeck/SteamDeck.cpp            | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/Source/Core/InputCommon/ControllerInterface/SteamDeck/SteamDeck.cpp b/Source/Core/InputCommon/ControllerInterface/SteamDeck/SteamDeck.cpp
+index 0a0dc88387..87504f77b8 100644
+--- a/Source/Core/InputCommon/ControllerInterface/SteamDeck/SteamDeck.cpp
++++ b/Source/Core/InputCommon/ControllerInterface/SteamDeck/SteamDeck.cpp
+@@ -288,14 +288,13 @@ void Device::UpdateInput()
+   if (++m_gyro_reenable == 250)
+   {
+     m_gyro_reenable = 0;
+-    // Using names from Valve's contribution to SDL for the Steam Controller
+-    // (and assuming this has not changed for the Deck), this packet decodes as:
++    // Using names from Valve's contribution to SDL this packet decodes as:
+     // 0x00 = report ID
+     // 0x87 = ID_SET_SETTINGS_VALUES
+     // 0x03 = payload length
+-    // 0x30 = SETTING_GYRO_MODE
++    // 0x30 = SETTING_IMU_MODE
+     // 0x18 0x00 = SETTING_GYRO_MODE_SEND_RAW_ACCEL | SETTING_GYRO_MODE_SEND_RAW_GYRO
+-    const unsigned char pkt[] = {0x00, 0x87, 0x03, 0x30, 0x18, 0x00};
++    const unsigned char pkt[65] = {0x00, 0x87, 0x03, 0x30, 0x18, 0x00};
+     hid_send_feature_report(m_device, pkt, sizeof(pkt));
+   }
+ 
+-- 
+2.45.2
+

--- a/appdata.xml
+++ b/appdata.xml
@@ -25,7 +25,7 @@
   </provides>
   <launchable type="desktop-id">io.github.shiiion.primehack.desktop</launchable>
   <releases>
-    <release date="2023-12-20" version="1.0.7"/>
+    <release date="2023-12-28" version="1.0.7a"/>
   </releases>
   <url type="homepage">https://github.com/shiiion/dolphin</url>
   <url type="help">https://github.com/shiiion/dolphin/wiki</url>

--- a/io.github.shiiion.primehack.yml
+++ b/io.github.shiiion.primehack.yml
@@ -86,7 +86,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/shiiion/dolphin.git
-        commit: bd2591a28ab4a367a3f11f65059e07314a13f081
+        commit: 03117e2947cd30237b760bd230037ef9513d63bc
       # detects whether dolphin is running in a flatpak sandbox
       # and makes it use xdg directories if it is.
       # prevents dolphin from attempting to write conf files

--- a/io.github.shiiion.primehack.yml
+++ b/io.github.shiiion.primehack.yml
@@ -97,6 +97,8 @@ modules:
       # version strings must match exactly for online multiplayer
       - type: patch
         path: nodirtyversion.patch
+      - type: patch
+        path: Steam-Deck-Control-Fix.patch
       - type: file
         path: appdata.xml
       - type: script


### PR DESCRIPTION
This is an issue that was fixed in Dolphin, but the fix didn't make it into primehack. Apparently it doesn't occur on all models of steam deck.

Details here: https://bugs.dolphin-emu.org/issues/13412

This issue was driving me absolutely insane, so I cherry-picked the relevant commit into a patch file and built a new flatpak for myself. Though you may prefer for the fix to land in primehack itself rather than pulling this in. Up to you.

Also updated primehack for good measure. v1.0.7a seems to include a minor bugfix of some kind.